### PR TITLE
Docker Setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM openjdk:17-jdk-slim
+
+WORKDIR /app
+
+# JAR 파일 복사 (빌드된 JAR 파일 이름에 맞춰 수정 필요)
+COPY build/libs/SayUp-0.0.1-SNAPSHOT.jar app.jar
+
+# 환경변수 설정
+ENV DB_CONNECTION=mysql
+ENV DB_NAME=sayup_db
+ENV DB_USERNAME=root
+ENV DB_PASSWORD=0000
+ENV FILE_UPLOAD_DIR=/file/temp
+ENV API_KEY=temp
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.8"
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: sayup_mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: "0000"
+      MYSQL_DATABASE: "sayup_db"
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - app_network
+
+  app:
+    build: .
+    container_name: sayup_app
+    restart: always
+    depends_on:
+      - mysql
+    environment:
+      DB_CONNECTION: "mysql"
+      DB_NAME: "sayup_db"
+      DB_USERNAME: "root"
+      DB_PASSWORD: "0000"
+      # 경로 변경 필요
+      FILE_UPLOAD_DIR: "/file/temp"
+      API_KEY: "temp"
+    ports:
+      - "8080:8080"
+    networks:
+      - app_network
+
+networks:
+  app_network:
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
Dockerfile과 docker-compose.yml 파일을 추가하여 MySQL과 함께 컨테이너 환경에서 실행할 수 있도록 설정했습니다.
현재 기본적인 실행은 가능하지만, 일부 설정은 추가적으로 조정이 필요할 수 있습니다!

#### 🛠 실행 방법
`docker-compose up --build -d`
`docker ps` -> sayup_mysql, sayup_app 컨테이너가 실행 중인지 확인
위 명령어 실행만으로 별도의 환경 설정 없이 서버 실행 가능

build/libs/SayUp-0.0.1-SNAPSHOT.jar이 존재해야 함.
없다면 먼저 Spring Boot 프로젝트 빌드: `./gradlew build
`
#### ✅ 추가 고려 사항
.env 파일을 만들어 환경변수 분리 가능 
로컬이 아닌 서버 배포 필요

